### PR TITLE
fix: logical in ModelNegativeADTnorm.r

### DIFF
--- a/R/ModelNegativeADTnorm.r
+++ b/R/ModelNegativeADTnorm.r
@@ -140,14 +140,15 @@ ModelNegativeADTnorm = function(cell_protein_matrix,
   if (isFALSE(length(mu1) == length(rownames(adt_log)))) {
     ad_name = setdiff(rownames(adt_log), names(mu1))
     warning(
-      paste0('empirical background cound not be fit for: ',
-             ad_name,
-             ' value returned will be log transformed without background correction'),
+      paste0('empirical background cound not be fit for ',
+             length(ad_name), ' proteins: ',
+             paste(ad_name, collapse = ', '),
+             '. Value returned will be log transformed without background correction.')
     )
     ad = as.numeric(rep(x = 0, length(ad_name)))
     names(ad) = ad_name
     mu1 = c(mu1 , ad)
-    mu1 = mu1[match(rownames(norm_adt) , names(mu1) )]
+    mu1 = mu1[match(rownames(adt_log) , names(mu1) )]
   }
   norm_adt = apply( adt_log, 2, function(x) (x - mu1) )
 

--- a/R/ModelNegativeADTnorm.r
+++ b/R/ModelNegativeADTnorm.r
@@ -137,7 +137,7 @@ ModelNegativeADTnorm = function(cell_protein_matrix,
     mclust::Mclust(data = x, G = 2, verbose = FALSE, warn = FALSE)
   })
   mu1 = unlist(lapply(p.model, function(x) x$parameters$mean[[1]]))
-  if (isFALSE(all.equal(length(mu1), length(rownames(adt_log))))) {
+  if (isFALSE(length(mu1) == length(rownames(adt_log)))) {
     ad_name = setdiff(rownames(adt_log), names(mu1))
     warning(
       paste0('empirical background cound not be fit for: ',


### PR DESCRIPTION

In `ModelNegativeADRnorm` there is a logical that will always return FALSE, and the corresponding if statement (dealing with the case when a model could not be fit for some markers) will thus never trigger. This PR fixes this.

The issue comes from the use of `all.equal`, which will return `TRUE` if all elements across two vectors are equal, and a string if they are not. The `isFALSE` function would thus return `FALSE` whether `all.equal` returns `TRUE` or a string. 

Here is an example:

```
mu1 <- 1:10
adt_log <- matrix(1:100, nrow = 10, ncol = 10)
rownames(adt_log) <- paste0("protein", 1:10)

# Lengths are equal, expected to return FALSE
isFALSE(length(mu1) == length(rownames(adt_log)))
# [1] FALSE

isFALSE(all.equal(length(mu1), length(rownames(adt_log))))        
# [1] FALSE



# Lengths are NOT equal, expected to return TRUE
mu1 <- 1:9

isFALSE(length(mu1) == length(rownames(adt_log)))
# [1] TRUE

isFALSE(all.equal(length(mu1), length(rownames(adt_log))))
# [1] FALSE
```

